### PR TITLE
Add Power Up Level to Pokestops and Gyms

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ Join the discussion @ [Discord](https://discord.gg/cG8JwrJB6Z)
   - candy: `<pokemon id>[_a{amount}].png`
   - xl_candy:`<pokemon id>[_a{amount}].png`
 ### Gym icons
-  - gym: `<team id>[_t{trainer count}][_b][_ex][_ar].png` (`_b` in active battle, `_ex` ex gym, `_ar` ar eligible (no flag means false))
+  - gym: `<team id>[_t{trainer count}][_b][_ex][_ar][_p{1-3}].png` (`_b` in active battle, `_ex` ex gym, `_ar` ar eligible (no flag means false), `_p` Power Up Level from AR Scan submissions)
 ### Raid icons 
   - egg: `<egg level>[_h][_ex].png` (`_h` hatched egg `_ex` ex gym (no flag means false))
 ### Invasion icons
   - invasion: `<grunt id>.png`
 ### Pokestop icons
-  - pokestop: `<lure id**>[_i][_q{with_ar}][_ar].png` ( `_i` invasion active, `_q` quest active, `_ar` ar eligible ) images from invasion and reward folder can be used as overlay
+  - pokestop: `<lure id**>[_i][_q{with_ar}][_ar][_p{1-3}].png` ( `_i` invasion active, `_q` quest active, `_ar` ar eligible, `_p` Power Up Level from AR Scan submissions) images from invasion and reward folder can be used as overlay
   - ** Not lured is ID `0` further follow proto's
   - Upcoming Pokestop levels might change perspective on pokestop icon naming.. TBC
   - `_q`: any or both AR and non-AR quests are active 


### PR DESCRIPTION
<!--- Edit README.mb to show what you want to change -->
<!--- This pr will result in a poll on Discord. If you get the majority on your side it will be included in the standard -->
<!--- Please create a seperate pull request for each of the changes you want where possible. Polls are done for the complete pr -->

Powering up POI's (Gyms and Pokestops) has been available for a while and can benefit players with extra balls or even extra pokemon spawns, a quick visual of such on a map may be beneficial.

**Changes**
adding _p for Power_up_Level to both gyms and Pokestops after the AR tag

**Examples**
`504_i7_ar_p3` Would be a Golden Pokéstop (Once pull31 is accepted) with a Magnetic Lure that is currently at AR scanable and at Level 3
![504_i7_ar_p3](https://user-images.githubusercontent.com/12138502/202289406-7b1ac3c1-95b2-42f0-9223-8014f27234da.png)
